### PR TITLE
システムレベル以外でプラグイン設定が行える問題に対策

### DIFF
--- a/plugins/Notification/config.yaml
+++ b/plugins/Notification/config.yaml
@@ -28,6 +28,6 @@ settings:
         default: Notification - <mt:var name="class_label"> '<mt:var name="object_title">' is published.
     notification_mail_body:
         default: <mt:var name="body">
-config_template: config.tmpl
+system_config_template: config.tmpl
 
 # TODO::save_filter


### PR DESCRIPTION
プラグイン設定はシステムレベルでのみ行える